### PR TITLE
Fix for incorrect handling of the 'stop' state.

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -36,6 +36,6 @@
     "en": "Bugfix for the app crashing."
   },
   "3.1.0": {
-    "en": "Correctly handling playing/non-playing states. Upgraded project structure to Homey Compose."
+    "en": "Correctly handling playing/non-playing states.\nUpgraded project structure to Homey Compose.\nNew maintainer."
   }
 }

--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -34,5 +34,8 @@
   },
   "3.0.8": {
     "en": "Bugfix for the app crashing."
+  },
+  "3.1.0": {
+    "en": "Correctly handling playing/non-playing states. Upgraded project structure to Homey Compose."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,11 +1,21 @@
 {
   "id": "com.bluesound",
+  "version": "3.1.0",
+  "compatibility": ">=5.0.0",
+  "platforms": [
+    "local"
+  ],
   "sdk": 3,
   "brandColor": "#000000",
   "name": {
     "en": "Bluesound",
     "nl": "Bluesound"
   },
+  "description": {
+    "en": "Multi-room Music. The Hi-Res Way.",
+    "nl": "Muziek voor meerdere kamers. De Hi-Res manier."
+  },
+  "category": "music",
   "tags": {
     "en": [
       "bluesound",
@@ -16,39 +26,31 @@
       "muziek"
     ]
   },
-  "version": "3.1.0",
-  "compatibility": ">=5.0.0",
-  "author": {
-    "name": "Jelger Haanstra",
-    "email": "homey@solidewebservices.com",
-    "website": "https://github.com/jghaanstra/com.bluesound"
-  },
-  "contributing": {
-    "donate": {
-      "paypal": {
-        "username": "jghaanstra"
-      }
-    }
-  },
-  "bugs": {
-    "url": "https://github.com/jghaanstra/com.bluesound/issues"
-  },
-  "homeyCommunityTopicId": 121,
-  "source": "https://github.com/jghaanstra/com.bluesound",
   "images": {
     "small": "./assets/images/small.png",
     "large": "./assets/images/large.png",
     "xlarge": "./assets/images/xlarge.png"
   },
-  "category": "music",
-  "description": {
-    "en": "Control your Bluesound devices with Homey",
-    "nl": "Bedien je Bluesound apparaten via Homey"
+  "author": {
+    "name": "Roelof Oomen"
   },
-  "dependencies": {
-    "net": "*"
+  "contributors": {
+    "developers": [
+      {
+        "name": "Jelger Haanstra"
+      }
+    ]
   },
-  "platforms": [
-    "local"
-  ]
+  "contributing": {
+    "donate": {
+      "paypal": {
+        "username": "rjoomen"
+      }
+    }
+  },
+  "bugs": {
+    "url": "https://github.com/rjoomen/com.bluesound/issues"
+  },
+  "homeyCommunityTopicId": 121,
+  "source": "https://github.com/rjoomen/com.bluesound"
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,0 +1,54 @@
+{
+  "id": "com.bluesound",
+  "sdk": 3,
+  "brandColor": "#000000",
+  "name": {
+    "en": "Bluesound",
+    "nl": "Bluesound"
+  },
+  "tags": {
+    "en": [
+      "bluesound",
+      "music"
+    ],
+    "nl": [
+      "bluesound",
+      "muziek"
+    ]
+  },
+  "version": "3.1.0",
+  "compatibility": ">=5.0.0",
+  "author": {
+    "name": "Jelger Haanstra",
+    "email": "homey@solidewebservices.com",
+    "website": "https://github.com/jghaanstra/com.bluesound"
+  },
+  "contributing": {
+    "donate": {
+      "paypal": {
+        "username": "jghaanstra"
+      }
+    }
+  },
+  "bugs": {
+    "url": "https://github.com/jghaanstra/com.bluesound/issues"
+  },
+  "homeyCommunityTopicId": 121,
+  "source": "https://github.com/jghaanstra/com.bluesound",
+  "images": {
+    "small": "./assets/images/small.png",
+    "large": "./assets/images/large.png",
+    "xlarge": "./assets/images/xlarge.png"
+  },
+  "category": "music",
+  "description": {
+    "en": "Control your Bluesound devices with Homey",
+    "nl": "Bedien je Bluesound apparaten via Homey"
+  },
+  "dependencies": {
+    "net": "*"
+  },
+  "platforms": [
+    "local"
+  ]
+}

--- a/app.json
+++ b/app.json
@@ -1,127 +1,65 @@
 {
-	"id": "com.bluesound",
-	"sdk": 3,
+  "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
+  "id": "com.bluesound",
+  "sdk": 3,
   "brandColor": "#000000",
-	"name": {
-		"en": "Bluesound",
-		"nl": "Bluesound"
-	},
-	"tags": {
-		"en": [ "bluesound", "music" ],
-		"nl": [ "bluesound", "muziek" ]
-	},
-	"version": "3.0.8",
-	"compatibility": ">=5.0.0",
-	"author": {
-		"name": "Jelger Haanstra",
-		"email": "homey@solidewebservices.com",
-		"website": "https://github.com/jghaanstra/com.bluesound"
-	},
-	"contributing": {
-		"donate": {
-			"paypal": {
-				"username": "jghaanstra"
-			}
-		}
-	},
-	"bugs": {
-		"url": "https://github.com/jghaanstra/com.bluesound/issues"
-	},
+  "name": {
+    "en": "Bluesound",
+    "nl": "Bluesound"
+  },
+  "tags": {
+    "en": [
+      "bluesound",
+      "music"
+    ],
+    "nl": [
+      "bluesound",
+      "muziek"
+    ]
+  },
+  "version": "3.1.0",
+  "compatibility": ">=5.0.0",
+  "author": {
+    "name": "Jelger Haanstra",
+    "email": "homey@solidewebservices.com",
+    "website": "https://github.com/jghaanstra/com.bluesound"
+  },
+  "contributing": {
+    "donate": {
+      "paypal": {
+        "username": "jghaanstra"
+      }
+    }
+  },
+  "bugs": {
+    "url": "https://github.com/jghaanstra/com.bluesound/issues"
+  },
   "homeyCommunityTopicId": 121,
   "source": "https://github.com/jghaanstra/com.bluesound",
-  "homepage": "https://community.athom.com/t/121",
-	"images": {
-		"small": "./assets/images/small.png",
+  "images": {
+    "small": "./assets/images/small.png",
     "large": "./assets/images/large.png",
     "xlarge": "./assets/images/xlarge.png"
-	},
-	"category": "music",
-	"description": {
-		"en": "Control your Bluesound devices with Homey",
-		"nl": "Bedien je Bluesound apparaten via Homey"
-	},
-	"dependencies": {
-		"net": "*"
-	},
-	"drivers": [
-		{
-			"id": "bluesound",
-			"name": {
-				"en": "Bluesound",
-				"nl": "Bluesound"
-			},
-			"images": {
-				"small": "drivers/bluesound/assets/images/small.jpg",
-        "large": "drivers/bluesound/assets/images/large.jpg",
-        "xlarge": "drivers/bluesound/assets/images/xlarge.jpg"
-			},
-			"class": "speaker",
-			"capabilities": [
-        "speaker_playing",
-				"speaker_prev",
-				"speaker_next",
-				"volume_set",
-				"volume_mute"
-			],
-			"pair": [
-				{
-					"id": "start"
-				}
-			],
-			"settings": [
-				{
-					"type": "group",
-					"label": {
-						"en": "Bluesound settings",
-						"nl": "Bluesound instellingen"
-					},
-					"children": [
-						{
-							"id": "address",
-							"type": "text",
-							"value": "0.0.0.0",
-							"label": {
-								"en": "IP Address",
-								"nl": "IP adres"
-							}
-						},
-						{
-							"id": "port",
-							"type": "number",
-							"value": 11000,
-							"step": 1,
-							"label": {
-								"en": "Port",
-								"nl": "Poort"
-							}
-						},
-						{
-							"id": "polling",
-							"type": "number",
-							"value": 4,
-							"step": 1,
-							"attr": {
-								"min": 4,
-								"max": 3600
-							},
-							"label": {
-								"en": "Polling",
-								"nl": "Polling"
-							}
-						}
-					]
-				}
-			]
-		}
-	],
+  },
+  "category": "music",
+  "description": {
+    "en": "Control your Bluesound devices with Homey",
+    "nl": "Bedien je Bluesound apparaten via Homey"
+  },
+  "dependencies": {
+    "net": "*"
+  },
+  "platforms": [
+    "local"
+  ],
   "flow": {
     "triggers": [
       {
-			  "id": "start_playing",
-			  "title": {
+        "id": "start_playing",
+        "title": {
           "en": "Start Playing",
           "nl": "Start afspelen"
-			  },
+        },
         "tokens": [
           {
             "name": "album",
@@ -136,8 +74,8 @@
             "name": "track",
             "type": "string",
             "title": {
-                "en": "Track",
-                "nl": "Track"
+              "en": "Track",
+              "nl": "Track"
             },
             "example": "Would?"
           },
@@ -151,42 +89,34 @@
             "example": "Alice in Chains"
           }
         ],
-	      "args": [
+        "args": [
           {
-		        "name": "device",
-		        "type": "device",
-		        "placeholder": {
-			        "en": "Select Bluesound device",
-			        "nl": "Selecteer Bluesound apparaat"
-		        },
-		        "filter": "driver_id=bluesound"
-	        }
-				]
-			},
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          }
+        ]
+      },
       {
-				"id": "stop_playing",
-				"title": {
+        "id": "stop_playing",
+        "title": {
           "en": "Stop Playing",
           "nl": "Stop afspelen"
-				},
-				"args": [
+        },
+        "args": [
           {
-						"name": "device",
-						"type": "device",
-						"placeholder": {
-							"en": "Select Bluesound device",
-							"nl": "Selecteer Bluesound apparaat"
-						},
-						"filter": "driver_id=bluesound"
-					}
-				]
-			},
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          }
+        ]
+      },
       {
-				"id": "artist_changed",
-				"title": {
+        "id": "artist_changed",
+        "title": {
           "en": "Artist changed",
           "nl": "Artiest gewijzigd"
-				},
+        },
         "tokens": [
           {
             "name": "album",
@@ -216,24 +146,20 @@
             "example": "Alice in Chains"
           }
         ],
-				"args": [
+        "args": [
           {
-						"name": "device",
-						"type": "device",
-						"placeholder": {
-							"en": "Select Bluesound device",
-							"nl": "Selecteer Bluesound apparaat"
-						},
-						"filter": "driver_id=bluesound"
-					}
-				]
-			},
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          }
+        ]
+      },
       {
-				"id": "track_changed",
-				"title": {
+        "id": "track_changed",
+        "title": {
           "en": "Track changed",
           "nl": "Track gewijzigd"
-				},
+        },
         "tokens": [
           {
             "name": "album",
@@ -263,51 +189,48 @@
             "example": "Alice in Chains"
           }
         ],
-				"args": [
+        "args": [
           {
-						"name": "device",
-						"type": "device",
-						"placeholder": {
-							"en": "Select Bluesound device",
-							"nl": "Selecteer Bluesound apparaat"
-						},
-						"filter": "driver_id=bluesound"
-					}
-				]
-			}
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          }
+        ]
+      }
     ],
     "conditions": [
       {
-				"id": "shuffled",
-				"title": {
+        "id": "shuffled",
+        "title": {
           "en": "!{{is|is not}} shuffled",
           "nl": "!{{is|is niet}} shuffled"
-				},
-				"args": [
+        },
+        "args": [
           {
-						"name": "device",
-						"type": "device",
-						"placeholder": {
-							"en": "Select Bluesound device",
-							"nl": "Selecteer Bluesound apparaat"
-						},
-						"filter": "driver_id=bluesound"
-					}
-				]
-			}
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          }
+        ]
+      }
     ],
     "actions": [
-			{
-				"id": "repeat",
-				"title": {
+      {
+        "id": "repeat",
+        "title": {
           "en": "Repeat",
           "nl": "Herhaal"
-				},
+        },
         "titleFormatted": {
           "en": "Set repeat to [[repeat]]",
           "nl": "Instellen repeat op [[repeat]]"
         },
         "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          },
           {
             "type": "dropdown",
             "name": "repeat",
@@ -334,29 +257,25 @@
                 }
               }
             ]
-          },
-          {
-						"name": "device",
-						"type": "device",
-						"placeholder": {
-							"en": "Select Bluesound device",
-							"nl": "Selecteer Bluesound apparaat"
-						},
-						"filter": "driver_id=bluesound"
-					}
-				]
-			},
+          }
+        ]
+      },
       {
-				"id": "shuffle",
-				"title": {
+        "id": "shuffle",
+        "title": {
           "en": "Shuffle",
           "nl": "Shuffle"
-				},
+        },
         "titleFormatted": {
           "en": "Set shuffle to [[shuffle]]",
           "nl": "Instellen shuffle op [[shuffle]]"
         },
         "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          },
           {
             "type": "dropdown",
             "name": "shuffle",
@@ -376,29 +295,25 @@
                 }
               }
             ]
-          },
-          {
-						"name": "device",
-						"type": "device",
-						"placeholder": {
-							"en": "Select Bluesound device",
-							"nl": "Selecteer Bluesound apparaat"
-						},
-						"filter": "driver_id=bluesound"
-					}
-				]
-			},
+          }
+        ]
+      },
       {
-				"id": "changeinput",
-				"title": {
+        "id": "changeinput",
+        "title": {
           "en": "Change input",
           "nl": "Verander input"
-				},
+        },
         "titleFormatted": {
           "en": "Change input to [[inputs]]",
           "nl": "Wijzig input naar [[inputs]]"
         },
         "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          },
           {
             "type": "autocomplete",
             "name": "inputs",
@@ -406,29 +321,25 @@
               "en": "Select input",
               "nl": "Selecteer input"
             }
-          },
-          {
-	          "name": "device",
-	          "type": "device",
-	          "placeholder": {
-	            "en": "Select Bluesound device",
-		          "nl": "Selecteer Bluesound apparaat"
-				    },
-				    "filter": "driver_id=bluesound"
-			    }
-			  ]
-			},
+          }
+        ]
+      },
       {
-				"id": "changeservice",
-				"title": {
+        "id": "changeservice",
+        "title": {
           "en": "Change service",
           "nl": "Verander service"
-				},
+        },
         "titleFormatted": {
           "en": "Change service to [[services]]",
           "nl": "Wijzig service naar [[services]]"
         },
         "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          },
           {
             "type": "autocomplete",
             "name": "services",
@@ -436,29 +347,25 @@
               "en": "Select service",
               "nl": "Selecteer service"
             }
-          },
-          {
-						"name": "device",
-						"type": "device",
-						"placeholder": {
-							"en": "Select Bluesound device",
-							"nl": "Selecteer Bluesound apparaat"
-						},
-						"filter": "driver_id=bluesound"
-					}
-				]
-			},
+          }
+        ]
+      },
       {
-				"id": "playpreset",
-				"title": {
+        "id": "playpreset",
+        "title": {
           "en": "Play Preset",
           "nl": "Speel preset"
-				},
+        },
         "titleFormatted": {
           "en": "Play preset [[preset]]",
           "nl": "Speel preset [[preset]]"
         },
         "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          },
           {
             "type": "number",
             "name": "preset",
@@ -469,29 +376,25 @@
               "en": "Select preset",
               "nl": "Selecteer preset"
             }
-          },
-          {
-						"name": "device",
-						"type": "device",
-						"placeholder": {
-							"en": "Select Bluesound device",
-							"nl": "Selecteer Bluesound apparaat"
-						},
-						"filter": "driver_id=bluesound"
-					}
-				]
-			},
+          }
+        ]
+      },
       {
-				"id": "addslave",
-				"title": {
+        "id": "addslave",
+        "title": {
           "en": "Add slave",
           "nl": "Toevoegen slave"
-				},
+        },
         "titleFormatted": {
           "en": "Add slave with ip [[ip]] to group [[group]]",
           "nl": "Toevoegen slave met ip [[ip]] aan groep [[group]]"
         },
         "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          },
           {
             "type": "text",
             "name": "ip",
@@ -507,29 +410,25 @@
               "en": "Group Name",
               "nl": "Groepsnaam"
             }
-          },
-          {
-			      "name": "device",
-		        "type": "device",
-		        "placeholder": {
-			        "en": "Select Bluesound device",
-			        "nl": "Selecteer Bluesound apparaat"
-		        },
-					  "filter": "driver_id=bluesound"
-					}
-				]
-			},
+          }
+        ]
+      },
       {
-				"id": "removeslave",
-				"title": {
+        "id": "removeslave",
+        "title": {
           "en": "Remove slave",
           "nl": "Verwijderen slave"
-				},
+        },
         "titleFormatted": {
           "en": "Remove slave with ip [[ip]]",
           "nl": "Verwijder slave met ip [[ip]]"
         },
         "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          },
           {
             "type": "text",
             "name": "ip",
@@ -537,33 +436,29 @@
               "en": "Slave IP",
               "nl": "Slave IP"
             }
-          },
-          {
-						"name": "device",
-						"type": "device",
-						"placeholder": {
-							"en": "Select Bluesound device",
-							"nl": "Selecteer Bluesound apparaat"
-						},
-						"filter": "driver_id=bluesound"
-					}
-				]
-			},
+          }
+        ]
+      },
       {
-				"id": "switchinput",
-				"title": {
+        "id": "switchinput",
+        "title": {
           "en": "Switch input",
           "nl": "Schakel input"
-				},
+        },
         "titleFormatted": {
           "en": "Change to [[direction]] input",
           "nl": "Wijzig naar [[direction]] input"
         },
         "hint": {
-					"en": "Use this card to switch to the next or previous input",
-					"nl": "Gebruik deze card om naar de vorige of volgende input te gaan"
-				},
+          "en": "Use this card to switch to the next or previous input",
+          "nl": "Gebruik deze card om naar de vorige of volgende input te gaan"
+        },
         "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          },
           {
             "type": "dropdown",
             "name": "direction",
@@ -583,29 +478,25 @@
                 }
               }
             ]
-          },
-          {
-						"name": "device",
-						"type": "device",
-						"placeholder": {
-							"en": "Select Bluesound device",
-							"nl": "Selecteer Bluesound apparaat"
-						},
-						"filter": "driver_id=bluesound"
-					}
-				]
-			},
+          }
+        ]
+      },
       {
-				"id": "setRelativeVolume",
-				"title": {
+        "id": "setRelativeVolume",
+        "title": {
           "en": "Set Relative Volume",
           "nl": "Relatief volume instellen"
-				},
+        },
         "titleFormatted": {
           "en": "Set relative volume to [[volume]]",
           "nl": "Instellen relatieve volume op [[volume]]"
         },
         "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          },
           {
             "type": "range",
             "name": "volume",
@@ -615,33 +506,29 @@
             "label": "%",
             "labelMultiplier": 100,
             "labelDecimals": 0
-          },
-          {
-						"name": "device",
-						"type": "device",
-						"placeholder": {
-							"en": "Select Bluesound device",
-							"nl": "Selecteer Bluesound apparaat"
-						},
-						"filter": "driver_id=bluesound"
-					}
-				]
-			},
+          }
+        ]
+      },
       {
-				"id": "sendcommand",
-				"title": {
+        "id": "sendcommand",
+        "title": {
           "en": "Send Command",
           "nl": "Verstuur commando"
-				},
+        },
         "titleFormatted": {
           "en": "Send command [[command]]",
           "nl": "Verstuur commando [[command]]"
         },
         "hint": {
-					"en": "Use this card to send any custom command to to your Bluesound device, for instance Genres?service=LocalMusic",
-					"nl": "Gebruik deze card om elk aangepast commando naar je Bluesound apparaat te versturen, b.v. Genres?service=LocalMusic"
-				},
+          "en": "Use this card to send any custom command to to your Bluesound device, for instance Genres?service=LocalMusic",
+          "nl": "Gebruik deze card om elk aangepast commando naar je Bluesound apparaat te versturen, b.v. Genres?service=LocalMusic"
+        },
         "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=bluesound"
+          },
           {
             "type": "text",
             "name": "command",
@@ -649,18 +536,80 @@
               "en": "Command",
               "nl": "Commando"
             }
-          },
-          {
-						"name": "device",
-						"type": "device",
-						"placeholder": {
-							"en": "Select Bluesound device",
-							"nl": "Selecteer Bluesound apparaat"
-						},
-						"filter": "driver_id=bluesound"
-					}
-				]
-			}
+          }
+        ]
+      }
     ]
-  }
+  },
+  "drivers": [
+    {
+      "name": {
+        "en": "Bluesound",
+        "nl": "Bluesound"
+      },
+      "images": {
+        "small": "drivers/bluesound/assets/images/small.jpg",
+        "large": "drivers/bluesound/assets/images/large.jpg",
+        "xlarge": "drivers/bluesound/assets/images/xlarge.jpg"
+      },
+      "class": "speaker",
+      "capabilities": [
+        "speaker_playing",
+        "speaker_prev",
+        "speaker_next",
+        "volume_set",
+        "volume_mute"
+      ],
+      "pair": [
+        {
+          "id": "start"
+        }
+      ],
+      "settings": [
+        {
+          "type": "group",
+          "label": {
+            "en": "Bluesound settings",
+            "nl": "Bluesound instellingen"
+          },
+          "children": [
+            {
+              "id": "address",
+              "type": "text",
+              "value": "0.0.0.0",
+              "label": {
+                "en": "IP Address",
+                "nl": "IP adres"
+              }
+            },
+            {
+              "id": "port",
+              "type": "number",
+              "value": 11000,
+              "step": 1,
+              "label": {
+                "en": "Port",
+                "nl": "Poort"
+              }
+            },
+            {
+              "id": "polling",
+              "type": "number",
+              "value": 4,
+              "step": 1,
+              "attr": {
+                "min": 4,
+                "max": 3600
+              },
+              "label": {
+                "en": "Polling",
+                "nl": "Polling"
+              }
+            }
+          ]
+        }
+      ],
+      "id": "bluesound"
+    }
+  ]
 }

--- a/app.json
+++ b/app.json
@@ -1,12 +1,22 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.bluesound",
+  "version": "3.1.0",
+  "compatibility": ">=5.0.0",
+  "platforms": [
+    "local"
+  ],
   "sdk": 3,
   "brandColor": "#000000",
   "name": {
     "en": "Bluesound",
     "nl": "Bluesound"
   },
+  "description": {
+    "en": "Multi-room Music. The Hi-Res Way.",
+    "nl": "Muziek voor meerdere kamers. De Hi-Res manier."
+  },
+  "category": "music",
   "tags": {
     "en": [
       "bluesound",
@@ -17,41 +27,33 @@
       "muziek"
     ]
   },
-  "version": "3.1.0",
-  "compatibility": ">=5.0.0",
-  "author": {
-    "name": "Jelger Haanstra",
-    "email": "homey@solidewebservices.com",
-    "website": "https://github.com/jghaanstra/com.bluesound"
-  },
-  "contributing": {
-    "donate": {
-      "paypal": {
-        "username": "jghaanstra"
-      }
-    }
-  },
-  "bugs": {
-    "url": "https://github.com/jghaanstra/com.bluesound/issues"
-  },
-  "homeyCommunityTopicId": 121,
-  "source": "https://github.com/jghaanstra/com.bluesound",
   "images": {
     "small": "./assets/images/small.png",
     "large": "./assets/images/large.png",
     "xlarge": "./assets/images/xlarge.png"
   },
-  "category": "music",
-  "description": {
-    "en": "Control your Bluesound devices with Homey",
-    "nl": "Bedien je Bluesound apparaten via Homey"
+  "author": {
+    "name": "Roelof Oomen"
   },
-  "dependencies": {
-    "net": "*"
+  "contributors": {
+    "developers": [
+      {
+        "name": "Jelger Haanstra"
+      }
+    ]
   },
-  "platforms": [
-    "local"
-  ],
+  "contributing": {
+    "donate": {
+      "paypal": {
+        "username": "rjoomen"
+      }
+    }
+  },
+  "bugs": {
+    "url": "https://github.com/rjoomen/com.bluesound/issues"
+  },
+  "homeyCommunityTopicId": 121,
+  "source": "https://github.com/rjoomen/com.bluesound",
   "flow": {
     "triggers": [
       {

--- a/drivers/bluesound/device.js
+++ b/drivers/bluesound/device.js
@@ -69,12 +69,18 @@ class BluesoundDevice extends Homey.Device {
         }
 
         // capability speaker_playing
-        if (result.state != "pause" && !this.getCapabilityValue('speaker_playing')) {
-          this.setCapabilityValue('speaker_playing', true);
-          this.homey.flow.getDeviceTriggerCard('start_playing').trigger(this, {artist: result.artist, track: result.track, album: result.album}, {});
-        } else if (result.state == "pause" && this.getCapabilityValue('speaker_playing')) {
-          this.setCapabilityValue('speaker_playing', false);
-          this.homey.flow.getDeviceTriggerCard('stop_playing').trigger(this, {}, {});
+        if ((result.state == 'play') || (result.state == 'stream')) {
+          // playing
+          if (!this.getCapabilityValue('speaker_playing')) {
+            this.setCapabilityValue('speaker_playing', true);
+            this.homey.flow.getDeviceTriggerCard('start_playing').trigger(this, {artist: result.artist, track: result.track, album: result.album}, {});
+          }
+        } else {
+          // not playing
+          if (this.getCapabilityValue('speaker_playing')) {
+            this.setCapabilityValue('speaker_playing', false);
+            this.homey.flow.getDeviceTriggerCard('stop_playing').trigger(this, {}, {});
+          }
         }
 
         // capability volume_set and volume_mute

--- a/drivers/bluesound/driver.compose.json
+++ b/drivers/bluesound/driver.compose.json
@@ -1,0 +1,68 @@
+{
+  "name": {
+    "en": "Bluesound",
+    "nl": "Bluesound"
+  },
+  "images": {
+    "small": "drivers/bluesound/assets/images/small.jpg",
+    "large": "drivers/bluesound/assets/images/large.jpg",
+    "xlarge": "drivers/bluesound/assets/images/xlarge.jpg"
+  },
+  "class": "speaker",
+  "capabilities": [
+    "speaker_playing",
+    "speaker_prev",
+    "speaker_next",
+    "volume_set",
+    "volume_mute"
+  ],
+  "pair": [
+    {
+      "id": "start"
+    }
+  ],
+  "settings": [
+    {
+      "type": "group",
+      "label": {
+        "en": "Bluesound settings",
+        "nl": "Bluesound instellingen"
+      },
+      "children": [
+        {
+          "id": "address",
+          "type": "text",
+          "value": "0.0.0.0",
+          "label": {
+            "en": "IP Address",
+            "nl": "IP adres"
+          }
+        },
+        {
+          "id": "port",
+          "type": "number",
+          "value": 11000,
+          "step": 1,
+          "label": {
+            "en": "Port",
+            "nl": "Poort"
+          }
+        },
+        {
+          "id": "polling",
+          "type": "number",
+          "value": 4,
+          "step": 1,
+          "attr": {
+            "min": 4,
+            "max": 3600
+          },
+          "label": {
+            "en": "Polling",
+            "nl": "Polling"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/drivers/bluesound/driver.flow.compose.json
+++ b/drivers/bluesound/driver.flow.compose.json
@@ -1,0 +1,409 @@
+{
+  "triggers": [
+    {
+      "id": "start_playing",
+      "title": {
+        "en": "Start Playing",
+        "nl": "Start afspelen"
+      },
+      "tokens": [
+        {
+          "name": "album",
+          "type": "string",
+          "title": {
+            "en": "Album",
+            "nl": "Album"
+          },
+          "example": "Dirt"
+        },
+        {
+          "name": "track",
+          "type": "string",
+          "title": {
+            "en": "Track",
+            "nl": "Track"
+          },
+          "example": "Would?"
+        },
+        {
+          "name": "artist",
+          "type": "string",
+          "title": {
+            "en": "Artist",
+            "nl": "Artist"
+          },
+          "example": "Alice in Chains"
+        }
+      ],
+      "args": []
+    },
+    {
+      "id": "stop_playing",
+      "title": {
+        "en": "Stop Playing",
+        "nl": "Stop afspelen"
+      },
+      "args": []
+    },
+    {
+      "id": "artist_changed",
+      "title": {
+        "en": "Artist changed",
+        "nl": "Artiest gewijzigd"
+      },
+      "tokens": [
+        {
+          "name": "album",
+          "type": "string",
+          "title": {
+            "en": "Album",
+            "nl": "Album"
+          },
+          "example": "Dirt"
+        },
+        {
+          "name": "track",
+          "type": "string",
+          "title": {
+            "en": "Track",
+            "nl": "Track"
+          },
+          "example": "Would?"
+        },
+        {
+          "name": "artist",
+          "type": "string",
+          "title": {
+            "en": "Artist",
+            "nl": "Artist"
+          },
+          "example": "Alice in Chains"
+        }
+      ],
+      "args": []
+    },
+    {
+      "id": "track_changed",
+      "title": {
+        "en": "Track changed",
+        "nl": "Track gewijzigd"
+      },
+      "tokens": [
+        {
+          "name": "album",
+          "type": "string",
+          "title": {
+            "en": "Album",
+            "nl": "Album"
+          },
+          "example": "Dirt"
+        },
+        {
+          "name": "track",
+          "type": "string",
+          "title": {
+            "en": "Track",
+            "nl": "Track"
+          },
+          "example": "Would?"
+        },
+        {
+          "name": "artist",
+          "type": "string",
+          "title": {
+            "en": "Artist",
+            "nl": "Artist"
+          },
+          "example": "Alice in Chains"
+        }
+      ],
+      "args": []
+    }
+  ],
+  "conditions": [
+    {
+      "id": "shuffled",
+      "title": {
+        "en": "!{{is|is not}} shuffled",
+        "nl": "!{{is|is niet}} shuffled"
+      },
+      "args": []
+    }
+  ],
+  "actions": [
+    {
+      "id": "repeat",
+      "title": {
+        "en": "Repeat",
+        "nl": "Herhaal"
+      },
+      "titleFormatted": {
+        "en": "Set repeat to [[repeat]]",
+        "nl": "Instellen repeat op [[repeat]]"
+      },
+      "args": [
+        {
+          "type": "dropdown",
+          "name": "repeat",
+          "values": [
+            {
+              "id": "0",
+              "label": {
+                "en": "On",
+                "nl": "Aan"
+              }
+            },
+            {
+              "id": "1",
+              "label": {
+                "en": "Track",
+                "nl": "Track"
+              }
+            },
+            {
+              "id": "2",
+              "label": {
+                "en": "Off",
+                "nl": "Uit"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "shuffle",
+      "title": {
+        "en": "Shuffle",
+        "nl": "Shuffle"
+      },
+      "titleFormatted": {
+        "en": "Set shuffle to [[shuffle]]",
+        "nl": "Instellen shuffle op [[shuffle]]"
+      },
+      "args": [
+        {
+          "type": "dropdown",
+          "name": "shuffle",
+          "values": [
+            {
+              "id": "0",
+              "label": {
+                "en": "Off",
+                "nl": "Uit"
+              }
+            },
+            {
+              "id": "1",
+              "label": {
+                "en": "On",
+                "nl": "Aan"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "changeinput",
+      "title": {
+        "en": "Change input",
+        "nl": "Verander input"
+      },
+      "titleFormatted": {
+        "en": "Change input to [[inputs]]",
+        "nl": "Wijzig input naar [[inputs]]"
+      },
+      "args": [
+        {
+          "type": "autocomplete",
+          "name": "inputs",
+          "placeholder": {
+            "en": "Select input",
+            "nl": "Selecteer input"
+          }
+        }
+      ]
+    },
+    {
+      "id": "changeservice",
+      "title": {
+        "en": "Change service",
+        "nl": "Verander service"
+      },
+      "titleFormatted": {
+        "en": "Change service to [[services]]",
+        "nl": "Wijzig service naar [[services]]"
+      },
+      "args": [
+        {
+          "type": "autocomplete",
+          "name": "services",
+          "placeholder": {
+            "en": "Select service",
+            "nl": "Selecteer service"
+          }
+        }
+      ]
+    },
+    {
+      "id": "playpreset",
+      "title": {
+        "en": "Play Preset",
+        "nl": "Speel preset"
+      },
+      "titleFormatted": {
+        "en": "Play preset [[preset]]",
+        "nl": "Speel preset [[preset]]"
+      },
+      "args": [
+        {
+          "type": "number",
+          "name": "preset",
+          "min": 1,
+          "max": 100,
+          "step": 1,
+          "placeholder": {
+            "en": "Select preset",
+            "nl": "Selecteer preset"
+          }
+        }
+      ]
+    },
+    {
+      "id": "addslave",
+      "title": {
+        "en": "Add slave",
+        "nl": "Toevoegen slave"
+      },
+      "titleFormatted": {
+        "en": "Add slave with ip [[ip]] to group [[group]]",
+        "nl": "Toevoegen slave met ip [[ip]] aan groep [[group]]"
+      },
+      "args": [
+        {
+          "type": "text",
+          "name": "ip",
+          "placeholder": {
+            "en": "Slave IP",
+            "nl": "Slave IP"
+          }
+        },
+        {
+          "type": "text",
+          "name": "group",
+          "placeholder": {
+            "en": "Group Name",
+            "nl": "Groepsnaam"
+          }
+        }
+      ]
+    },
+    {
+      "id": "removeslave",
+      "title": {
+        "en": "Remove slave",
+        "nl": "Verwijderen slave"
+      },
+      "titleFormatted": {
+        "en": "Remove slave with ip [[ip]]",
+        "nl": "Verwijder slave met ip [[ip]]"
+      },
+      "args": [
+        {
+          "type": "text",
+          "name": "ip",
+          "placeholder": {
+            "en": "Slave IP",
+            "nl": "Slave IP"
+          }
+        }
+      ]
+    },
+    {
+      "id": "switchinput",
+      "title": {
+        "en": "Switch input",
+        "nl": "Schakel input"
+      },
+      "titleFormatted": {
+        "en": "Change to [[direction]] input",
+        "nl": "Wijzig naar [[direction]] input"
+      },
+      "hint": {
+        "en": "Use this card to switch to the next or previous input",
+        "nl": "Gebruik deze card om naar de vorige of volgende input te gaan"
+      },
+      "args": [
+        {
+          "type": "dropdown",
+          "name": "direction",
+          "values": [
+            {
+              "id": "previous",
+              "label": {
+                "en": "Previous",
+                "nl": "Vorige"
+              }
+            },
+            {
+              "id": "next",
+              "label": {
+                "en": "Next",
+                "nl": "Volgende"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "setRelativeVolume",
+      "title": {
+        "en": "Set Relative Volume",
+        "nl": "Relatief volume instellen"
+      },
+      "titleFormatted": {
+        "en": "Set relative volume to [[volume]]",
+        "nl": "Instellen relatieve volume op [[volume]]"
+      },
+      "args": [
+        {
+          "type": "range",
+          "name": "volume",
+          "min": -1,
+          "max": 1,
+          "step": 0.1,
+          "label": "%",
+          "labelMultiplier": 100,
+          "labelDecimals": 0
+        }
+      ]
+    },
+    {
+      "id": "sendcommand",
+      "title": {
+        "en": "Send Command",
+        "nl": "Verstuur commando"
+      },
+      "titleFormatted": {
+        "en": "Send command [[command]]",
+        "nl": "Verstuur commando [[command]]"
+      },
+      "hint": {
+        "en": "Use this card to send any custom command to to your Bluesound device, for instance Genres?service=LocalMusic",
+        "nl": "Gebruik deze card om elk aangepast commando naar je Bluesound apparaat te versturen, b.v. Genres?service=LocalMusic"
+      },
+      "args": [
+        {
+          "type": "text",
+          "name": "command",
+          "placeholder": {
+            "en": "Command",
+            "nl": "Commando"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
-    "": {
-      "name": "com.bluesound",
-      "version": "3.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.7",
-        "xml2js": "^0.4.23"
-      },
-      "devDependencies": {}
-    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -76,54 +66,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    }
-  },
-  "dependencies": {
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
-    "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     }
   }
 }


### PR DESCRIPTION
Previously, only the 'pause' state was interpreted as not playing, causing the player to be reported as playing when in the 'stop' state. From the documentation it seems that only 'play' and 'stream' are possible playing states; the code has been modified accordingly.

Because the Homey VSCode plugin did not work with the old style project structure, I also had to upgrade it to Homey Compose.